### PR TITLE
fix: #33 最大料金0円を入力できないようにする

### DIFF
--- a/app/Http/Controllers/ParkingSpotController.php
+++ b/app/Http/Controllers/ParkingSpotController.php
@@ -108,6 +108,7 @@ class ParkingSpotController extends Controller
             'unit_minutes' => $rate->unit_minutes,
             'rate' => $rate->rate,
             'free_minutes' => $rate->free_minutes,
+            'no_free_minutes' => $rate->free_minutes === 0 ? '1' : '0',
             'max_rate' => $rate->max_rate,
             'no_max_rate' => $rate->max_rate === null ? '1' : '0',
         ])->values()->all() ?: [$this->defaultRateInput()]);
@@ -140,6 +141,7 @@ class ParkingSpotController extends Controller
             'unit_minutes' => 30,
             'rate' => '',
             'free_minutes' => 0,
+            'no_free_minutes' => '1',
             'max_rate' => '',
             'no_max_rate' => '0',
         ];

--- a/app/Http/Requests/ParkingSpotRequest.php
+++ b/app/Http/Requests/ParkingSpotRequest.php
@@ -65,7 +65,7 @@ class ParkingSpotRequest extends FormRequest
             'rates.*.free_minutes' => 'nullable|integer|min:0',
             'rates.*.no_free_minutes' => 'nullable|boolean',
             'rates.*.no_max_rate' => 'nullable|boolean',
-            'rates.*.max_rate' => 'required_unless:rates.*.no_max_rate,1|nullable|integer|min:0',
+            'rates.*.max_rate' => 'required_unless:rates.*.no_max_rate,1|nullable|integer|min:1',
         ];
     }
 
@@ -129,7 +129,7 @@ class ParkingSpotRequest extends FormRequest
             'rates.*.free_minutes.min' => '無料時間は0分以上で入力してください。',
 
             'rates.*.max_rate.integer' => '最大料金は整数で入力してください。',
-            'rates.*.max_rate.min' => '最大料金は0円以上で入力してください。',
+            'rates.*.max_rate.min' => '最大料金は1円以上で入力してください。',
             'rates.*.max_rate.required_unless' => '最大料金なしを選択しない場合、最大料金は必須です。',
         ];
     }

--- a/app/Http/Requests/ParkingSpotRequest.php
+++ b/app/Http/Requests/ParkingSpotRequest.php
@@ -17,6 +17,21 @@ class ParkingSpotRequest extends FormRequest
         return true;
     }
 
+    protected function prepareForValidation(): void
+    {
+        $rates = collect($this->input('rates', []))
+            ->map(function ($rate) {
+                if (($rate['no_free_minutes'] ?? false)) {
+                    $rate['free_minutes'] = 0;
+                }
+
+                return $rate;
+            })
+            ->all();
+
+        $this->merge(['rates' => $rates]);
+    }
+
     /**
      * Get the validation rules that apply to the request.
      *
@@ -48,6 +63,7 @@ class ParkingSpotRequest extends FormRequest
             'rates.*.unit_minutes' => ['required', 'integer', Rule::in(array_keys(config('categories.parking_spot_rate_unit_minutes')))],
             'rates.*.rate' => 'required|integer|min:0',
             'rates.*.free_minutes' => 'nullable|integer|min:0',
+            'rates.*.no_free_minutes' => 'nullable|boolean',
             'rates.*.no_max_rate' => 'nullable|boolean',
             'rates.*.max_rate' => 'required_unless:rates.*.no_max_rate,1|nullable|integer|min:0',
         ];

--- a/resources/views/parking_spot/partials/rates-form.blade.php
+++ b/resources/views/parking_spot/partials/rates-form.blade.php
@@ -85,9 +85,17 @@
                 <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
                     <div>
                         <x-input-label>最初の無料時間（分）</x-input-label>
-                        <input class="w-full rounded border p-2" name="rates[{{ $index }}][free_minutes]"
+                        <input class="free-minutes-input w-full rounded border p-2" name="rates[{{ $index }}][free_minutes]"
                             data-rate-field="free_minutes" type="number" value="{{ $rate['free_minutes'] ?? 0 }}"
                             min="0" placeholder="例：30">
+                        <label
+                            class="mt-2 flex items-center gap-2 rounded border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-700">
+                            <input
+                                class="no-free-minutes-checkbox rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500"
+                                name="rates[{{ $index }}][no_free_minutes]" data-rate-field="no_free_minutes"
+                                type="checkbox" value="1" @checked($rate['no_free_minutes'] ?? ((int) ($rate['free_minutes'] ?? 0) === 0))>
+                            <span>無料時間なし</span>
+                        </label>
                     </div>
 
                     <div>
@@ -164,8 +172,15 @@
             <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
                 <div>
                     <x-input-label>最初の無料時間（分）</x-input-label>
-                    <input class="w-full rounded border p-2" data-rate-field="free_minutes" type="number"
+                    <input class="free-minutes-input w-full rounded border p-2" data-rate-field="free_minutes" type="number"
                         value="0" min="0" placeholder="例：30">
+                    <label
+                        class="mt-2 flex items-center gap-2 rounded border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-700">
+                        <input
+                            class="no-free-minutes-checkbox rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500"
+                            data-rate-field="no_free_minutes" type="checkbox" value="1" checked>
+                        <span>無料時間なし</span>
+                    </label>
                 </div>
 
                 <div>
@@ -199,6 +214,25 @@
                 const addButton = root.querySelector('#add-rate-button');
                 const maxRates = 4;
 
+                const syncFreeMinutesState = (item) => {
+                    const checkbox = item.querySelector('.no-free-minutes-checkbox');
+                    const input = item.querySelector('.free-minutes-input');
+
+                    if (!checkbox || !input) {
+                        return;
+                    }
+
+                    input.readOnly = checkbox.checked;
+                    input.classList.toggle('bg-gray-200', checkbox.checked);
+                    input.classList.toggle('text-gray-500', checkbox.checked);
+                    input.classList.toggle('cursor-not-allowed', checkbox.checked);
+                    input.classList.toggle('bg-white', !checkbox.checked);
+
+                    if (checkbox.checked) {
+                        input.value = '0';
+                    }
+                };
+
                 const syncMaxRateState = (item) => {
                     const checkbox = item.querySelector('.no-max-rate-checkbox');
                     const input = item.querySelector('.max-rate-input');
@@ -228,6 +262,7 @@
                         item.querySelectorAll('[data-rate-field]').forEach((field) => {
                             field.name = `rates[${index}][${field.dataset.rateField}]`;
                         });
+                        syncFreeMinutesState(item);
                         syncMaxRateState(item);
                     });
 
@@ -257,11 +292,14 @@
                 });
 
                 list.addEventListener('change', (event) => {
-                    if (!event.target.classList.contains('no-max-rate-checkbox')) {
+                    if (!event.target.classList.contains('no-max-rate-checkbox') &&
+                        !event.target.classList.contains('no-free-minutes-checkbox')) {
                         return;
                     }
 
-                    syncMaxRateState(event.target.closest('.rate-item'));
+                    const item = event.target.closest('.rate-item');
+                    syncFreeMinutesState(item);
+                    syncMaxRateState(item);
                 });
 
                 renumberRates();

--- a/resources/views/parking_spot/partials/rates-form.blade.php
+++ b/resources/views/parking_spot/partials/rates-form.blade.php
@@ -102,7 +102,7 @@
                         <x-input-label>最大料金（円）</x-input-label>
                         <input class="max-rate-input w-full rounded border p-2"
                             name="rates[{{ $index }}][max_rate]" data-rate-field="max_rate" type="number"
-                            value="{{ $rate['max_rate'] ?? '' }}" min="0" placeholder="例：1200">
+                            value="{{ $rate['max_rate'] ?? '' }}" min="1" placeholder="例：1200">
                         <label
                             class="mt-2 flex items-center gap-2 rounded border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-700">
                             <input
@@ -186,7 +186,7 @@
                 <div>
                     <x-input-label>最大料金（円）</x-input-label>
                     <input class="max-rate-input w-full rounded border p-2" data-rate-field="max_rate" type="number"
-                        min="0" placeholder="例：1200">
+                        min="1" placeholder="例：1200">
                     <label
                         class="mt-2 flex items-center gap-2 rounded border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-700">
                         <input

--- a/tests/Feature/ParkingSpotRateDisplayTest.php
+++ b/tests/Feature/ParkingSpotRateDisplayTest.php
@@ -11,6 +11,7 @@ use App\Models\User;
 use App\Services\ParkingSpotService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
 class ParkingSpotRateDisplayTest extends TestCase
@@ -62,6 +63,8 @@ class ParkingSpotRateDisplayTest extends TestCase
 
         $response->assertOk();
         $response->assertSee('30分 100円 / 最大料金なし');
+        $response->assertDontSee('最初の0分無料');
+        $response->assertDontSee('以降30分 100円');
     }
 
     public function test_parking_spot_detail_displays_placeholder_without_rates(): void
@@ -151,6 +154,52 @@ class ParkingSpotRateDisplayTest extends TestCase
         $response->assertSeeText('12時間');
         $response->assertSee('<option value="1440"', false);
         $response->assertSeeText('24時間');
+    }
+
+    public function test_parking_spot_create_form_can_select_no_free_minutes(): void
+    {
+        [, $user] = $this->createParkingSpot();
+
+        $response = $this->actingAs($user)
+            ->get(route('parking_spot.create'));
+
+        $response->assertOk();
+        $response->assertSeeText('無料時間なし');
+        $response->assertSee('name="rates[0][no_free_minutes]"', false);
+        $response->assertSee('data-rate-field="no_free_minutes"', false);
+    }
+
+    public function test_no_free_minutes_input_is_normalized_on_confirm(): void
+    {
+        [, $user, $postalcode] = $this->createParkingSpot();
+        Http::fake([
+            '*' => Http::response([
+                'Feature' => [
+                    [
+                        'Geometry' => ['Coordinates' => '139.753000,35.685000'],
+                        'Property' => ['Address' => '東京都千代田区千代田1-2'],
+                    ],
+                ],
+            ]),
+        ]);
+
+        $response = $this->actingAs($user)
+            ->from(route('parking_spot.create'))
+            ->post(route('parking_spot.confirm'), $this->validParkingSpotInput($postalcode, [
+                'rates' => [
+                    $this->validRateInput([
+                        'free_minutes' => 30,
+                        'no_free_minutes' => '1',
+                    ]),
+                ],
+            ]));
+
+        $response->assertOk();
+        $response->assertSessionMissing('errors');
+        $response->assertSessionHas('create_parking_spot_form.rates.0.free_minutes', 0);
+        $response->assertDontSee('最初の30分無料');
+        $response->assertDontSee('最初の0分無料');
+        $response->assertSee('30分 100円');
     }
 
     public function test_parking_spot_can_save_rate_without_max_rate(): void

--- a/tests/Feature/ParkingSpotRateDisplayTest.php
+++ b/tests/Feature/ParkingSpotRateDisplayTest.php
@@ -238,39 +238,22 @@ class ParkingSpotRateDisplayTest extends TestCase
         ]);
     }
 
-    public function test_zero_yen_max_rate_is_saved_distinctly(): void
+    public function test_parking_spot_rate_validation_rejects_zero_yen_max_rate(): void
     {
         [, $user, $postalcode] = $this->createParkingSpot();
 
-        $this->actingAs($user);
-
-        app(ParkingSpotService::class)->saveParkingSpot([
-            'name' => '最大料金0円テスト駐車場',
-            'postalcode' => $postalcode->postalcode,
-            'address' => '東京都千代田区千代田1-2',
-            'longitude' => 139.753000,
-            'latitude' => 35.685000,
-            'capacity' => 1,
-            'opening_time' => '00:00',
-            'closing_time' => '00:00',
-            'rates' => [
-                [
-                    'day_type' => '全日',
-                    'start_time' => '00:00',
-                    'end_time' => '00:00',
-                    'unit_minutes' => 30,
-                    'rate' => 100,
-                    'free_minutes' => 0,
-                    'max_rate' => 0,
+        $response = $this->actingAs($user)
+            ->from(route('parking_spot.create'))
+            ->post(route('parking_spot.confirm'), $this->validParkingSpotInput($postalcode, [
+                'rates' => [
+                    $this->validRateInput([
+                        'max_rate' => 0,
+                    ]),
                 ],
-            ],
-        ]);
+            ]));
 
-        $this->assertDatabaseHas('parking_spot_rates', [
-            'day_type' => '全日',
-            'rate' => 100,
-            'max_rate' => 0,
-        ]);
+        $response->assertRedirect(route('parking_spot.create'));
+        $response->assertSessionHasErrors(['rates.0.max_rate']);
     }
 
     public function test_parking_spot_can_replace_rates_on_update(): void
@@ -315,7 +298,7 @@ class ParkingSpotRateDisplayTest extends TestCase
                     'unit_minutes' => 15,
                     'rate' => 50,
                     'free_minutes' => 0,
-                    'max_rate' => 0,
+                    'max_rate' => 500,
                 ],
             ],
         ]);


### PR DESCRIPTION
Closes #33\n\n最大料金 0 円を弾くバリデーションとフォームの最小値を調整し、関連テストを更新しました。