### PR TITLE
fix: #49 料金重複判定を改善

### DIFF
--- a/app/Http/Requests/ParkingSpotRequest.php
+++ b/app/Http/Requests/ParkingSpotRequest.php
@@ -6,6 +6,7 @@ use App\Models\Postalcode;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
 
 class ParkingSpotRequest extends FormRequest
 {
@@ -30,6 +31,13 @@ class ParkingSpotRequest extends FormRequest
             ->all();
 
         $this->merge(['rates' => $rates]);
+    }
+
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $validator) {
+            $this->validateRateTimeConflicts($validator);
+        });
     }
 
     /**
@@ -132,5 +140,105 @@ class ParkingSpotRequest extends FormRequest
             'rates.*.max_rate.min' => '最大料金は1円以上で入力してください。',
             'rates.*.max_rate.required_unless' => '最大料金なしを選択しない場合、最大料金は必須です。',
         ];
+    }
+
+    private function validateRateTimeConflicts(Validator $validator): void
+    {
+        $rates = $this->input('rates');
+
+        if (! is_array($rates) || $validator->errors()->has('rates')) {
+            return;
+        }
+
+        $validatedRates = collect($rates)
+            ->map(fn ($rate, $index) => ['index' => $index, 'rate' => $rate])
+            ->filter(fn (array $item) => $this->isReadyForTimeConflictCheck($item['rate'], $item['index'], $validator))
+            ->groupBy(fn (array $item) => $item['rate']['day_type']);
+
+        foreach ($validatedRates as $dayType => $groupedRates) {
+            $groupedRates = $groupedRates->values();
+
+            for ($left = 0; $left < $groupedRates->count(); $left++) {
+                for ($right = $left + 1; $right < $groupedRates->count(); $right++) {
+                    $leftRate = $groupedRates[$left];
+                    $rightRate = $groupedRates[$right];
+
+                    if (! $this->hasTimeOverlap($leftRate['rate'], $rightRate['rate'])) {
+                        continue;
+                    }
+
+                    $message = $this->buildTimeConflictMessage($leftRate['index'], $rightRate['index'], $dayType);
+
+                    $validator->errors()->add("rates.{$leftRate['index']}.time_conflict", $message);
+                    $validator->errors()->add("rates.{$rightRate['index']}.time_conflict", $message);
+                }
+            }
+        }
+    }
+
+    private function isReadyForTimeConflictCheck(array $rate, int $index, Validator $validator): bool
+    {
+        $fields = ['day_type', 'start_time', 'end_time'];
+
+        foreach ($fields as $field) {
+            if ($validator->errors()->has("rates.{$index}.{$field}")) {
+                return false;
+            }
+        }
+
+        if (! isset($rate['day_type'], $rate['start_time'], $rate['end_time'])) {
+            return false;
+        }
+
+        return in_array($rate['day_type'], array_keys(config('categories.parking_spot_rate_day_types')), true)
+            && preg_match('/^\d{2}:\d{2}$/', $rate['start_time']) === 1
+            && preg_match('/^\d{2}:\d{2}$/', $rate['end_time']) === 1;
+    }
+
+    private function hasTimeOverlap(array $leftRate, array $rightRate): bool
+    {
+        foreach ($this->expandTimeRanges($leftRate['start_time'], $leftRate['end_time']) as [$leftStart, $leftEnd]) {
+            foreach ($this->expandTimeRanges($rightRate['start_time'], $rightRate['end_time']) as [$rightStart, $rightEnd]) {
+                if (max($leftStart, $rightStart) < min($leftEnd, $rightEnd)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function expandTimeRanges(string $startTime, string $endTime): array
+    {
+        $start = $this->timeToMinutes($startTime);
+        $end = $this->timeToMinutes($endTime);
+
+        if ($start === $end) {
+            return [[0, 1440]];
+        }
+
+        if ($start < $end) {
+            return [[$start, $end]];
+        }
+
+        return [
+            [$start, 1440],
+            [0, $end],
+        ];
+    }
+
+    private function timeToMinutes(string $time): int
+    {
+        [$hours, $minutes] = array_map('intval', explode(':', $time));
+
+        return ($hours * 60) + $minutes;
+    }
+
+    private function buildTimeConflictMessage(int $leftIndex, int $rightIndex, string $dayType): string
+    {
+        $leftNumber = $leftIndex + 1;
+        $rightNumber = $rightIndex + 1;
+
+        return "料金帯{$leftNumber}と料金帯{$rightNumber}の「{$dayType}」の時間帯が重複しています。同じ区分では重複しないように設定してください。";
     }
 }

--- a/app/Http/Requests/ParkingSpotRequest.php
+++ b/app/Http/Requests/ParkingSpotRequest.php
@@ -153,25 +153,30 @@ class ParkingSpotRequest extends FormRequest
         $validatedRates = collect($rates)
             ->map(fn ($rate, $index) => ['index' => $index, 'rate' => $rate])
             ->filter(fn (array $item) => $this->isReadyForTimeConflictCheck($item['rate'], $item['index'], $validator))
-            ->groupBy(fn (array $item) => $item['rate']['day_type']);
+            ->values();
 
-        foreach ($validatedRates as $dayType => $groupedRates) {
-            $groupedRates = $groupedRates->values();
+        for ($left = 0; $left < $validatedRates->count(); $left++) {
+            for ($right = $left + 1; $right < $validatedRates->count(); $right++) {
+                $leftRate = $validatedRates[$left];
+                $rightRate = $validatedRates[$right];
 
-            for ($left = 0; $left < $groupedRates->count(); $left++) {
-                for ($right = $left + 1; $right < $groupedRates->count(); $right++) {
-                    $leftRate = $groupedRates[$left];
-                    $rightRate = $groupedRates[$right];
-
-                    if (! $this->hasTimeOverlap($leftRate['rate'], $rightRate['rate'])) {
-                        continue;
-                    }
-
-                    $message = $this->buildTimeConflictMessage($leftRate['index'], $rightRate['index'], $dayType);
-
-                    $validator->errors()->add("rates.{$leftRate['index']}.time_conflict", $message);
-                    $validator->errors()->add("rates.{$rightRate['index']}.time_conflict", $message);
+                if (! $this->hasDayTypeOverlap($leftRate['rate']['day_type'], $rightRate['rate']['day_type'])) {
+                    continue;
                 }
+
+                if (! $this->hasTimeOverlap($leftRate['rate'], $rightRate['rate'])) {
+                    continue;
+                }
+
+                $message = $this->buildTimeConflictMessage(
+                    $leftRate['index'],
+                    $leftRate['rate']['day_type'],
+                    $rightRate['index'],
+                    $rightRate['rate']['day_type'],
+                );
+
+                $validator->errors()->add("rates.{$leftRate['index']}.time_conflict", $message);
+                $validator->errors()->add("rates.{$rightRate['index']}.time_conflict", $message);
             }
         }
     }
@@ -208,6 +213,23 @@ class ParkingSpotRequest extends FormRequest
         return false;
     }
 
+    private function hasDayTypeOverlap(string $leftDayType, string $rightDayType): bool
+    {
+        return count(array_intersect(
+            $this->dayTypeScopes($leftDayType),
+            $this->dayTypeScopes($rightDayType),
+        )) > 0;
+    }
+
+    private function dayTypeScopes(string $dayType): array
+    {
+        return match ($dayType) {
+            '平日' => ['weekday'],
+            '土日祝' => ['holiday'],
+            default => ['weekday', 'holiday'],
+        };
+    }
+
     private function expandTimeRanges(string $startTime, string $endTime): array
     {
         $start = $this->timeToMinutes($startTime);
@@ -234,11 +256,11 @@ class ParkingSpotRequest extends FormRequest
         return ($hours * 60) + $minutes;
     }
 
-    private function buildTimeConflictMessage(int $leftIndex, int $rightIndex, string $dayType): string
+    private function buildTimeConflictMessage(int $leftIndex, string $leftDayType, int $rightIndex, string $rightDayType): string
     {
         $leftNumber = $leftIndex + 1;
         $rightNumber = $rightIndex + 1;
 
-        return "料金帯{$leftNumber}と料金帯{$rightNumber}の「{$dayType}」の時間帯が重複しています。同じ区分では重複しないように設定してください。";
+        return "料金帯{$leftNumber}の「{$leftDayType}」と料金帯{$rightNumber}の「{$rightDayType}」は適用条件が重複しています。";
     }
 }

--- a/app/Models/ParkingSpotRates.php
+++ b/app/Models/ParkingSpotRates.php
@@ -66,6 +66,10 @@ class ParkingSpotRates extends Model
 
     public static function formatTimeRange(?string $startTime, ?string $endTime): string
     {
+        if (self::isFullDayRange($startTime, $endTime)) {
+            return '00:00 ～ 24:00';
+        }
+
         $startLabel = self::formatTimeLabel($startTime);
         $endLabel = self::formatTimeLabel($endTime, self::isOvernight($startTime, $endTime));
 
@@ -84,6 +88,16 @@ class ParkingSpotRates extends Model
         }
 
         return self::normalizeTime($startTime) > self::normalizeTime($endTime);
+    }
+
+    private static function isFullDayRange(?string $startTime, ?string $endTime): bool
+    {
+        if ($startTime === null || $endTime === null) {
+            return false;
+        }
+
+        return self::normalizeTime($startTime) === '00:00'
+            && self::normalizeTime($endTime) === '00:00';
     }
 
     private static function formatTimeLabel(?string $time, bool $isNextDay = false): string

--- a/resources/views/parking_spot/partials/rates-form.blade.php
+++ b/resources/views/parking_spot/partials/rates-form.blade.php
@@ -14,20 +14,6 @@
     @error('rates')
         <div class="mb-4 text-sm text-red-600">{{ $message }}</div>
     @enderror
-    @php
-        $rateErrors = collect($errors->getMessages())->filter(
-            fn($messages, $field) => str_starts_with($field, 'rates.'),
-        );
-    @endphp
-    @if ($rateErrors->isNotEmpty())
-        <div class="mb-4 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-600">
-            @foreach ($rateErrors as $messages)
-                @foreach ($messages as $message)
-                    <div>{{ $message }}</div>
-                @endforeach
-            @endforeach
-        </div>
-    @endif
 
     <div id="rate-list">
         @foreach ($ratesInput as $index => $rate)
@@ -38,6 +24,21 @@
                         削除
                     </button>
                 </div>
+
+                @php
+                    $itemErrors = collect($errors->getMessages())->filter(
+                        fn($messages, $field) => str_starts_with($field, "rates.{$index}."),
+                    );
+                @endphp
+                @if ($itemErrors->isNotEmpty())
+                    <div class="mb-4 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-600">
+                        @foreach ($itemErrors as $messages)
+                            @foreach ($messages as $message)
+                                <div>{{ $message }}</div>
+                            @endforeach
+                        @endforeach
+                    </div>
+                @endif
 
                 <div class="mb-4">
                     <x-input-label>料金区分</x-input-label>

--- a/tests/Feature/ParkingSpotRateDisplayTest.php
+++ b/tests/Feature/ParkingSpotRateDisplayTest.php
@@ -69,6 +69,7 @@ class ParkingSpotRateDisplayTest extends TestCase
         $response->assertOk();
         $response->assertSee('30分 100円');
         $response->assertSee('最大料金なし');
+        $response->assertSee('00:00 ～ 24:00');
         $response->assertDontSee('最初の0分無料');
         $response->assertDontSee('以降30分 100円');
     }
@@ -305,6 +306,36 @@ class ParkingSpotRateDisplayTest extends TestCase
         $response->assertOk();
         $response->assertSessionMissing('errors');
         $response->assertSee('22:00 ～ 翌06:00');
+    }
+
+    public function test_full_day_rate_is_displayed_as_midnight_to_24_on_confirm(): void
+    {
+        [, $user, $postalcode] = $this->createParkingSpot();
+        Http::fake([
+            '*' => Http::response([
+                'Feature' => [
+                    [
+                        'Geometry' => ['Coordinates' => '139.753000,35.685000'],
+                        'Property' => ['Address' => '東京都千代田区千代田1-2'],
+                    ],
+                ],
+            ]),
+        ]);
+
+        $response = $this->actingAs($user)
+            ->from(route('parking_spot.create'))
+            ->post(route('parking_spot.confirm'), $this->validParkingSpotInput($postalcode, [
+                'rates' => [
+                    $this->validRateInput([
+                        'start_time' => '00:00',
+                        'end_time' => '00:00',
+                    ]),
+                ],
+            ]));
+
+        $response->assertOk();
+        $response->assertSessionMissing('errors');
+        $response->assertSee('00:00 ～ 24:00');
     }
 
     public function test_parking_spot_can_save_rate_without_max_rate(): void

--- a/tests/Feature/ParkingSpotRateDisplayTest.php
+++ b/tests/Feature/ParkingSpotRateDisplayTest.php
@@ -513,6 +513,96 @@ class ParkingSpotRateDisplayTest extends TestCase
         $response->assertSessionHasErrors(['rates']);
     }
 
+    public function test_parking_spot_rate_validation_rejects_overlapping_ranges_with_same_day_type(): void
+    {
+        [, $user, $postalcode] = $this->createParkingSpot();
+
+        $response = $this->actingAs($user)
+            ->followingRedirects()
+            ->from(route('parking_spot.create'))
+            ->post(route('parking_spot.confirm'), $this->validParkingSpotInput($postalcode, [
+                'rates' => [
+                    $this->validRateInput([
+                        'day_type' => '平日',
+                        'start_time' => '08:00',
+                        'end_time' => '12:00',
+                    ]),
+                    $this->validRateInput([
+                        'day_type' => '平日',
+                        'start_time' => '11:00',
+                        'end_time' => '15:00',
+                    ]),
+                ],
+            ]));
+
+        $response->assertOk();
+        $response->assertSee('料金帯1と料金帯2の「平日」の時間帯が重複しています。');
+    }
+
+    public function test_parking_spot_rate_validation_rejects_overnight_overlap_on_edit_flow(): void
+    {
+        [$parkingSpot, $user, $postalcode] = $this->createParkingSpot();
+
+        $response = $this->actingAs($user)
+            ->followingRedirects()
+            ->from(route('parking_spot.edit', $parkingSpot->id))
+            ->post(route('parking_spot.confirm'), $this->validParkingSpotInput($postalcode, [
+                'id' => $parkingSpot->id,
+                'rates' => [
+                    $this->validRateInput([
+                        'day_type' => '夜間',
+                        'start_time' => '22:00',
+                        'end_time' => '06:00',
+                    ]),
+                    $this->validRateInput([
+                        'day_type' => '夜間',
+                        'start_time' => '05:30',
+                        'end_time' => '09:00',
+                    ]),
+                ],
+            ]));
+
+        $response->assertOk();
+        $response->assertSee('料金帯1と料金帯2の「夜間」の時間帯が重複しています。');
+    }
+
+    public function test_parking_spot_rate_validation_allows_adjacent_ranges_with_same_day_type(): void
+    {
+        [, $user, $postalcode] = $this->createParkingSpot();
+        Http::fake([
+            '*' => Http::response([
+                'Feature' => [
+                    [
+                        'Geometry' => ['Coordinates' => '139.753000,35.685000'],
+                        'Property' => ['Address' => '東京都千代田区千代田1-2'],
+                    ],
+                ],
+            ]),
+        ]);
+
+        $response = $this->actingAs($user)
+            ->from(route('parking_spot.create'))
+            ->post(route('parking_spot.confirm'), $this->validParkingSpotInput($postalcode, [
+                'rates' => [
+                    $this->validRateInput([
+                        'day_type' => '平日',
+                        'start_time' => '08:00',
+                        'end_time' => '12:00',
+                    ]),
+                    $this->validRateInput([
+                        'day_type' => '平日',
+                        'start_time' => '12:00',
+                        'end_time' => '18:00',
+                    ]),
+                ],
+            ]));
+
+        $response->assertOk();
+        $response->assertSessionMissing('errors');
+        $response->assertSee('08:00 ～ 12:00');
+        $response->assertSee('12:00 ～ 18:00');
+    }
+
     public function test_parking_spot_rate_validation_requires_max_rate_when_no_max_rate_is_off(): void
     {
         [, $user, $postalcode] = $this->createParkingSpot();

--- a/tests/Feature/ParkingSpotRateDisplayTest.php
+++ b/tests/Feature/ParkingSpotRateDisplayTest.php
@@ -567,7 +567,85 @@ class ParkingSpotRateDisplayTest extends TestCase
             ]));
 
         $response->assertOk();
-        $response->assertSee('料金帯1と料金帯2の「平日」の時間帯が重複しています。');
+        $response->assertSee('料金帯1の「平日」と料金帯2の「平日」は適用条件が重複しています。');
+    }
+
+    public function test_parking_spot_rate_validation_rejects_full_day_and_weekday_full_day_combination(): void
+    {
+        [, $user, $postalcode] = $this->createParkingSpot();
+
+        $response = $this->actingAs($user)
+            ->followingRedirects()
+            ->from(route('parking_spot.create'))
+            ->post(route('parking_spot.confirm'), $this->validParkingSpotInput($postalcode, [
+                'rates' => [
+                    $this->validRateInput([
+                        'day_type' => '全日',
+                        'start_time' => '00:00',
+                        'end_time' => '00:00',
+                    ]),
+                    $this->validRateInput([
+                        'day_type' => '平日',
+                        'start_time' => '00:00',
+                        'end_time' => '00:00',
+                    ]),
+                ],
+            ]));
+
+        $response->assertOk();
+        $response->assertSee('料金帯1の「全日」と料金帯2の「平日」は適用条件が重複しています。');
+    }
+
+    public function test_parking_spot_rate_validation_rejects_overlapping_ranges_with_different_broad_day_types(): void
+    {
+        [, $user, $postalcode] = $this->createParkingSpot();
+
+        $response = $this->actingAs($user)
+            ->followingRedirects()
+            ->from(route('parking_spot.create'))
+            ->post(route('parking_spot.confirm'), $this->validParkingSpotInput($postalcode, [
+                'rates' => [
+                    $this->validRateInput([
+                        'day_type' => '昼間',
+                        'start_time' => '09:00',
+                        'end_time' => '14:00',
+                    ]),
+                    $this->validRateInput([
+                        'day_type' => '夜間',
+                        'start_time' => '13:00',
+                        'end_time' => '18:00',
+                    ]),
+                ],
+            ]));
+
+        $response->assertOk();
+        $response->assertSee('料金帯1の「昼間」と料金帯2の「夜間」は適用条件が重複しています。');
+    }
+
+    public function test_parking_spot_rate_validation_rejects_overlapping_ranges_between_holiday_and_broad_day_type(): void
+    {
+        [, $user, $postalcode] = $this->createParkingSpot();
+
+        $response = $this->actingAs($user)
+            ->followingRedirects()
+            ->from(route('parking_spot.create'))
+            ->post(route('parking_spot.confirm'), $this->validParkingSpotInput($postalcode, [
+                'rates' => [
+                    $this->validRateInput([
+                        'day_type' => '土日祝',
+                        'start_time' => '10:00',
+                        'end_time' => '16:00',
+                    ]),
+                    $this->validRateInput([
+                        'day_type' => '昼間',
+                        'start_time' => '12:00',
+                        'end_time' => '18:00',
+                    ]),
+                ],
+            ]));
+
+        $response->assertOk();
+        $response->assertSee('料金帯1の「土日祝」と料金帯2の「昼間」は適用条件が重複しています。');
     }
 
     public function test_parking_spot_rate_validation_rejects_overnight_overlap_on_edit_flow(): void
@@ -594,7 +672,7 @@ class ParkingSpotRateDisplayTest extends TestCase
             ]));
 
         $response->assertOk();
-        $response->assertSee('料金帯1と料金帯2の「夜間」の時間帯が重複しています。');
+        $response->assertSee('料金帯1の「夜間」と料金帯2の「夜間」は適用条件が重複しています。');
     }
 
     public function test_parking_spot_rate_validation_allows_adjacent_ranges_with_same_day_type(): void
@@ -632,6 +710,139 @@ class ParkingSpotRateDisplayTest extends TestCase
         $response->assertSessionMissing('errors');
         $response->assertSee('08:00 ～ 12:00');
         $response->assertSee('12:00 ～ 18:00');
+    }
+
+    public function test_parking_spot_rate_validation_allows_adjacent_ranges_with_different_broad_day_types(): void
+    {
+        [, $user, $postalcode] = $this->createParkingSpot();
+        Http::fake([
+            '*' => Http::response([
+                'Feature' => [
+                    [
+                        'Geometry' => ['Coordinates' => '139.753000,35.685000'],
+                        'Property' => ['Address' => '東京都千代田区千代田1-2'],
+                    ],
+                ],
+            ]),
+        ]);
+
+        $response = $this->actingAs($user)
+            ->from(route('parking_spot.create'))
+            ->post(route('parking_spot.confirm'), $this->validParkingSpotInput($postalcode, [
+                'rates' => [
+                    $this->validRateInput([
+                        'day_type' => '昼間',
+                        'start_time' => '08:00',
+                        'end_time' => '18:00',
+                    ]),
+                    $this->validRateInput([
+                        'day_type' => '夜間',
+                        'start_time' => '18:00',
+                        'end_time' => '23:00',
+                    ]),
+                ],
+            ]));
+
+        $response->assertOk();
+        $response->assertSessionMissing('errors');
+        $response->assertSee('08:00 ～ 18:00');
+        $response->assertSee('18:00 ～ 23:00');
+    }
+
+    public function test_parking_spot_rate_validation_allows_weekday_and_holiday_full_day_combination(): void
+    {
+        [, $user, $postalcode] = $this->createParkingSpot();
+        Http::fake([
+            '*' => Http::response([
+                'Feature' => [
+                    [
+                        'Geometry' => ['Coordinates' => '139.753000,35.685000'],
+                        'Property' => ['Address' => '東京都千代田区千代田1-2'],
+                    ],
+                ],
+            ]),
+        ]);
+
+        $response = $this->actingAs($user)
+            ->from(route('parking_spot.create'))
+            ->post(route('parking_spot.confirm'), $this->validParkingSpotInput($postalcode, [
+                'rates' => [
+                    $this->validRateInput([
+                        'day_type' => '平日',
+                        'start_time' => '00:00',
+                        'end_time' => '00:00',
+                    ]),
+                    $this->validRateInput([
+                        'day_type' => '土日祝',
+                        'start_time' => '00:00',
+                        'end_time' => '00:00',
+                    ]),
+                ],
+            ]));
+
+        $response->assertOk();
+        $response->assertSessionMissing('errors');
+        $response->assertSee('00:00 ～ 24:00');
+    }
+
+    public function test_parking_spot_rate_validation_reports_only_format_error_when_time_fields_are_invalid(): void
+    {
+        [, $user, $postalcode] = $this->createParkingSpot();
+
+        $response = $this->actingAs($user)
+            ->followingRedirects()
+            ->from(route('parking_spot.create'))
+            ->post(route('parking_spot.confirm'), $this->validParkingSpotInput($postalcode, [
+                'rates' => [
+                    $this->validRateInput([
+                        'day_type' => '全日',
+                        'start_time' => '8時',
+                        'end_time' => '20:00',
+                    ]),
+                    $this->validRateInput([
+                        'day_type' => '平日',
+                        'start_time' => '09:00',
+                        'end_time' => '12:00',
+                    ]),
+                ],
+            ]));
+
+        $response->assertOk();
+        $response->assertSee('料金開始時間の形式が正しくありません。例: 08:00');
+        $response->assertDontSee('適用条件が重複しています。');
+    }
+
+    public function test_parking_spot_rate_validation_rejects_multiple_overlaps_from_one_full_day_rate(): void
+    {
+        [, $user, $postalcode] = $this->createParkingSpot();
+
+        $response = $this->actingAs($user)
+            ->followingRedirects()
+            ->from(route('parking_spot.create'))
+            ->post(route('parking_spot.confirm'), $this->validParkingSpotInput($postalcode, [
+                'rates' => [
+                    $this->validRateInput([
+                        'day_type' => '全日',
+                        'start_time' => '00:00',
+                        'end_time' => '00:00',
+                    ]),
+                    $this->validRateInput([
+                        'day_type' => '平日',
+                        'start_time' => '09:00',
+                        'end_time' => '18:00',
+                    ]),
+                    $this->validRateInput([
+                        'day_type' => '土日祝',
+                        'start_time' => '10:00',
+                        'end_time' => '17:00',
+                    ]),
+                ],
+            ]));
+
+        $response->assertOk();
+        $response->assertSee('料金帯1の「全日」と料金帯2の「平日」は適用条件が重複しています。');
+        $response->assertSee('料金帯1の「全日」と料金帯3の「土日祝」は適用条件が重複しています。');
+        $response->assertDontSee('料金帯2の「平日」と料金帯3の「土日祝」は適用条件が重複しています。');
     }
 
     public function test_parking_spot_rate_validation_requires_max_rate_when_no_max_rate_is_off(): void


### PR DESCRIPTION
## 概要
- 料金帯の重複バリデーションを追加
- 終日料金帯の時間表示を `00:00 ～ 24:00` に調整
- 区分またぎの重複判定と Feature テストを拡充

## 確認
- `vendor/bin/sail pint app/Http/Requests/ParkingSpotRequest.php resources/views/parking_spot/partials/rates-form.blade.php tests/Feature/ParkingSpotRateDisplayTest.php`
- `vendor/bin/sail test tests/Feature/ParkingSpotRateDisplayTest.php`
- `vendor/bin/sail pint app/Models/ParkingSpotRates.php tests/Feature/ParkingSpotRateDisplayTest.php`
- `vendor/bin/sail test tests/Feature/ParkingSpotRateDisplayTest.php`

Closes #49
