### PR TITLE
feat: #46 駐輪場画像の登録と表示に対応

### DIFF
--- a/app/Http/Controllers/ParkingSpotController.php
+++ b/app/Http/Controllers/ParkingSpotController.php
@@ -44,7 +44,9 @@ class ParkingSpotController extends Controller
     public function confirm(ParkingSpotRequest $request)
     {
         $validatedData = $request->validated();
+        unset($validatedData['image']);
         $validatedData['id'] = $request->input('id');
+        $validatedData['image_path'] = $this->service->prepareImagePathForConfirm($request, $validatedData['image_path'] ?? null);
         $validatedData['address'] = mb_convert_kana($validatedData['address1'].$validatedData['address2'], 'rn');
         $validatedData['postalcode'] = mb_convert_kana(str_replace('-', '', $validatedData['postalcode']), 'rn');
 
@@ -112,8 +114,9 @@ class ParkingSpotController extends Controller
             'max_rate' => $rate->max_rate,
             'no_max_rate' => $rate->max_rate === null ? '1' : '0',
         ])->values()->all() ?: [$this->defaultRateInput()]);
+        $imagePath = old('image_path', $parkingSpot->image_path);
 
-        return view('parking_spot.edit', compact('parkingSpot', 'capacity', 'rateDayTypes', 'rateUnitMinutes', 'postalcode', 'address1', 'address2', 'session', 'ratesInput'));
+        return view('parking_spot.edit', compact('parkingSpot', 'capacity', 'rateDayTypes', 'rateUnitMinutes', 'postalcode', 'address1', 'address2', 'session', 'ratesInput', 'imagePath'));
     }
 
     public function update(Request $request)

--- a/app/Http/Requests/ParkingSpotRequest.php
+++ b/app/Http/Requests/ParkingSpotRequest.php
@@ -54,6 +54,8 @@ class ParkingSpotRequest extends FormRequest
             ],
             'address2' => 'required|string|max:255',
             'capacity' => 'required|integer|min:1',
+            'image' => 'nullable|image|max:5120',
+            'image_path' => 'nullable|string|max:255',
             'opening_time' => 'required|date_format:H:i',
             'closing_time' => 'required|date_format:H:i',
             'rates' => 'required|array|min:1|max:4',
@@ -95,6 +97,11 @@ class ParkingSpotRequest extends FormRequest
             'capacity.required' => '駐車場台数は必須です。',
             'capacity.integer' => '駐車場台数は整数で入力してください。',
             'capacity.min' => '駐車場台数を設定してください。',
+
+            'image.image' => '画像ファイルを選択してください。',
+            'image.max' => '画像は5MB以下でアップロードしてください。',
+            'image_path.string' => '画像の保持情報が正しくありません。',
+            'image_path.max' => '画像の保持情報が長すぎます。',
 
             'opening_time.required' => '開場時間は必須です。',
             'opening_time.date_format' => '開場時間の形式が正しくありません。例: 10:00',

--- a/app/Http/Requests/ParkingSpotRequest.php
+++ b/app/Http/Requests/ParkingSpotRequest.php
@@ -54,7 +54,7 @@ class ParkingSpotRequest extends FormRequest
             ],
             'address2' => 'required|string|max:255',
             'capacity' => 'required|integer|min:1',
-            'image' => 'nullable|image|max:5120',
+            'image' => 'nullable|image|mimes:jpg,jpeg,png,webp|max:20480',
             'image_path' => 'nullable|string|max:255',
             'opening_time' => 'required|date_format:H:i',
             'closing_time' => 'required|date_format:H:i',
@@ -99,7 +99,8 @@ class ParkingSpotRequest extends FormRequest
             'capacity.min' => '駐車場台数を設定してください。',
 
             'image.image' => '画像ファイルを選択してください。',
-            'image.max' => '画像は5MB以下でアップロードしてください。',
+            'image.mimes' => '画像は jpg / jpeg / png / webp 形式でアップロードしてください。',
+            'image.max' => '画像は20MB以下でアップロードしてください。',
             'image_path.string' => '画像の保持情報が正しくありません。',
             'image_path.max' => '画像の保持情報が長すぎます。',
 

--- a/app/Models/ParkingSpot.php
+++ b/app/Models/ParkingSpot.php
@@ -5,10 +5,25 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Facades\Storage;
 
 class ParkingSpot extends Model
 {
     use HasFactory;
+
+    public function getImageUrlAttribute(): string
+    {
+        return self::imageUrlForPath($this->image_path);
+    }
+
+    public static function imageUrlForPath(?string $path): string
+    {
+        if (blank($path)) {
+            return asset('images/noimage.jpg');
+        }
+
+        return Storage::disk('public')->url($path);
+    }
 
     public function rates(): HasMany
     {

--- a/app/Services/ParkingSpotService.php
+++ b/app/Services/ParkingSpotService.php
@@ -6,6 +6,11 @@ use App\Models\ParkingSpot;
 use App\Models\ParkingSpotRates;
 use App\Models\Postalcode;
 use Carbon\CarbonImmutable;
+use Illuminate\Validation\ValidationException;
+use Intervention\Image\Drivers\Gd\Driver as GdDriver;
+use Intervention\Image\Drivers\Imagick\Driver as ImagickDriver;
+use Intervention\Image\Encoders\WebpEncoder;
+use Intervention\Image\ImageManager;
 use Illuminate\Http\Request;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
@@ -13,6 +18,8 @@ use Illuminate\Support\Facades\Storage;
 
 class ParkingSpotService
 {
+    private const MAX_FINAL_IMAGE_BYTES = 5 * 1024 * 1024;
+
     public function saveParkingSpot($input)
     {
         $postalcodeId = Postalcode::getPostalcodeId($input['postalcode'])->first()->id ?? null;
@@ -125,7 +132,20 @@ class ParkingSpotService
             Storage::disk('public')->delete($currentPath);
         }
 
-        return $request->file('image')->store('temp/parking-spots', 'public');
+        $timestamp = CarbonImmutable::now()->format('YmdHisv');
+        $tempPath = 'temp/parking-spots/'.$timestamp.'.webp';
+
+        try {
+            $webpBinary = $this->convertImageToWebpWithinLimit($request->file('image')->getRealPath());
+        } catch (\Throwable) {
+            throw ValidationException::withMessages([
+                'image' => '画像をWebP形式へ変換できませんでした。別の画像をお試しください。',
+            ]);
+        }
+
+        Storage::disk('public')->put($tempPath, $webpBinary);
+
+        return $tempPath;
     }
 
     private function persistConfirmedImage(ParkingSpot $parkingSpot, ?string $imagePath): ?string
@@ -140,9 +160,8 @@ class ParkingSpotService
             return null;
         }
 
-        $extension = pathinfo($imagePath, PATHINFO_EXTENSION);
         $timestamp = CarbonImmutable::now()->format('YmdHisv');
-        $filename = $parkingSpot->id.'_'.$timestamp.($extension ? '.'.$extension : '');
+        $filename = $parkingSpot->id.'_'.$timestamp.'.webp';
         $permanentPath = 'parking-spots/'.$filename;
 
         $disk->copy($imagePath, $permanentPath);
@@ -154,5 +173,53 @@ class ParkingSpotService
     private function isTemporaryImagePath(?string $path): bool
     {
         return filled($path) && str_starts_with($path, 'temp/parking-spots/');
+    }
+
+    private function convertImageToWebpWithinLimit(string $sourcePath): string
+    {
+        $manager = $this->imageManager();
+        $quality = 85;
+        $maxWidth = null;
+
+        while (true) {
+            $image = $manager->decodePath($sourcePath);
+
+            if ($maxWidth !== null && $image->width() > $maxWidth) {
+                $image = $image->scaleDown(width: $maxWidth);
+            }
+
+            $encoded = $image->encode(new WebpEncoder(quality: $quality));
+            $binary = (string) $encoded;
+
+            if (strlen($binary) <= self::MAX_FINAL_IMAGE_BYTES) {
+                return $binary;
+            }
+
+            if ($quality > 55) {
+                $quality -= 10;
+                continue;
+            }
+
+            $nextWidth = $maxWidth
+                ? (int) floor($maxWidth * 0.85)
+                : (int) floor($image->width() * 0.85);
+
+            if ($nextWidth < 600 || $nextWidth >= $image->width()) {
+                break;
+            }
+
+            $maxWidth = $nextWidth;
+        }
+
+        throw new \RuntimeException('Unable to convert image within size limit.');
+    }
+
+    private function imageManager(): ImageManager
+    {
+        if (extension_loaded('imagick')) {
+            return new ImageManager(new ImagickDriver);
+        }
+
+        return new ImageManager(new GdDriver);
     }
 }

--- a/app/Services/ParkingSpotService.php
+++ b/app/Services/ParkingSpotService.php
@@ -5,7 +5,11 @@ namespace App\Services;
 use App\Models\ParkingSpot;
 use App\Models\ParkingSpotRates;
 use App\Models\Postalcode;
+use Carbon\CarbonImmutable;
+use Illuminate\Http\Request;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
 
 class ParkingSpotService
 {
@@ -29,6 +33,9 @@ class ParkingSpotService
 
         $parkingSpot->save();
 
+        $parkingSpot->image_path = $this->persistConfirmedImage($parkingSpot, $input['image_path'] ?? null);
+        $parkingSpot->save();
+
         $this->saveParkingSpotRates($parkingSpot, $input['rates']);
     }
 
@@ -36,6 +43,7 @@ class ParkingSpotService
     {
         $id = $input['id'];
         $parkingSpot = ParkingSpot::findOrFail($id);
+        $originalImagePath = $parkingSpot->image_path;
 
         $postalcode = Postalcode::getPostalcodeId($input['postalcode'])->first()->id ?? null;
         if (! $postalcode) {
@@ -50,8 +58,13 @@ class ParkingSpotService
         $parkingSpot->opening_time = $input['opening_time'];
         $parkingSpot->closing_time = $input['closing_time'];
         $parkingSpot->capacity = $input['capacity'];
+        $parkingSpot->image_path = $this->persistConfirmedImage($parkingSpot, $input['image_path'] ?? null);
 
         $parkingSpot->save();
+
+        if ($originalImagePath && $originalImagePath !== $parkingSpot->image_path) {
+            Storage::disk('public')->delete($originalImagePath);
+        }
 
         $parkingSpot->rates()->delete();
         $this->saveParkingSpotRates($parkingSpot, $input['rates']);
@@ -100,5 +113,46 @@ class ParkingSpotService
 
             return $yolpLocation;
         }
+    }
+
+    public function prepareImagePathForConfirm(Request $request, ?string $currentPath): ?string
+    {
+        if (! $request->hasFile('image')) {
+            return $currentPath;
+        }
+
+        if ($this->isTemporaryImagePath($currentPath)) {
+            Storage::disk('public')->delete($currentPath);
+        }
+
+        return $request->file('image')->store('temp/parking-spots', 'public');
+    }
+
+    private function persistConfirmedImage(ParkingSpot $parkingSpot, ?string $imagePath): ?string
+    {
+        if (blank($imagePath) || ! $this->isTemporaryImagePath($imagePath)) {
+            return $imagePath;
+        }
+
+        $disk = Storage::disk('public');
+
+        if (! $disk->exists($imagePath)) {
+            return null;
+        }
+
+        $extension = pathinfo($imagePath, PATHINFO_EXTENSION);
+        $timestamp = CarbonImmutable::now()->format('YmdHisv');
+        $filename = $parkingSpot->id.'_'.$timestamp.($extension ? '.'.$extension : '');
+        $permanentPath = 'parking-spots/'.$filename;
+
+        $disk->copy($imagePath, $permanentPath);
+        $disk->delete($imagePath);
+
+        return $permanentPath;
+    }
+
+    private function isTemporaryImagePath(?string $path): bool
+    {
+        return filled($path) && str_starts_with($path, 'temp/parking-spots/');
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.3",
+        "intervention/image": "^4.2",
         "laravel/framework": "^13.0",
         "laravel/tinker": "^3.0",
         "livewire/livewire": "^3.6"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aabe079bd70a37116962c8d7d40441e1",
+    "content-hash": "da03505eeb42ee17e5a129fe5991d92d",
     "packages": [
         {
             "name": "brick/math",
@@ -1056,6 +1056,150 @@
                 }
             ],
             "time": "2026-07-08T16:19:22+00:00"
+        },
+        {
+            "name": "intervention/gif",
+            "version": "5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Intervention/gif.git",
+                "reference": "bb395af960deffe64d70c976b4df9283f68e762d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Intervention/gif/zipball/bb395af960deffe64d70c976b4df9283f68e762d",
+                "reference": "bb395af960deffe64d70c976b4df9283f68e762d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.3"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^12.0",
+                "slevomat/coding-standard": "~8.0",
+                "squizlabs/php_codesniffer": "^4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Intervention\\Gif\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Oliver Vogel",
+                    "email": "oliver@intervention.io",
+                    "homepage": "https://intervention.io/"
+                }
+            ],
+            "description": "PHP GIF Encoder/Decoder",
+            "homepage": "https://github.com/intervention/gif",
+            "keywords": [
+                "animation",
+                "gd",
+                "gif",
+                "image"
+            ],
+            "support": {
+                "issues": "https://github.com/Intervention/gif/issues",
+                "source": "https://github.com/Intervention/gif/tree/5.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://paypal.me/interventionio",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/Intervention",
+                    "type": "github"
+                },
+                {
+                    "url": "https://ko-fi.com/interventionphp",
+                    "type": "ko_fi"
+                }
+            ],
+            "time": "2026-05-03T06:04:47+00:00"
+        },
+        {
+            "name": "intervention/image",
+            "version": "4.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Intervention/image.git",
+                "reference": "830907fc5397dfc2a51a4e90322d586989fc8364"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Intervention/image/zipball/830907fc5397dfc2a51a4e90322d586989fc8364",
+                "reference": "830907fc5397dfc2a51a4e90322d586989fc8364",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "intervention/gif": "^5",
+                "php": "^8.3"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.6",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^12.0",
+                "slevomat/coding-standard": "~8.0",
+                "squizlabs/php_codesniffer": "^4"
+            },
+            "suggest": {
+                "ext-exif": "Recommended to be able to read EXIF data properly."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Intervention\\Image\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Oliver Vogel",
+                    "email": "oliver@intervention.io",
+                    "homepage": "https://intervention.io"
+                }
+            ],
+            "description": "PHP Image Processing",
+            "homepage": "https://image.intervention.io",
+            "keywords": [
+                "gd",
+                "image",
+                "imagick",
+                "resize",
+                "thumbnail",
+                "watermark"
+            ],
+            "support": {
+                "issues": "https://github.com/Intervention/image/issues",
+                "source": "https://github.com/Intervention/image/tree/4.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://paypal.me/interventionio",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/Intervention",
+                    "type": "github"
+                },
+                {
+                    "url": "https://ko-fi.com/interventionphp",
+                    "type": "ko_fi"
+                }
+            ],
+            "time": "2026-07-09T13:07:14+00:00"
         },
         {
             "name": "laravel/framework",
@@ -8522,12 +8666,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.3"
     },
-    "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "platform-dev": [],
+    "plugin-api-version": "2.2.0"
 }

--- a/database/migrations/2026_07_12_000001_add_image_path_to_parking_spots_table.php
+++ b/database/migrations/2026_07_12_000001_add_image_path_to_parking_spots_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('parking_spots', function (Blueprint $table) {
+            $table->string('image_path')->nullable()->after('capacity');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('parking_spots', function (Blueprint $table) {
+            $table->dropColumn('image_path');
+        });
+    }
+};

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -28,7 +28,7 @@
             <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
                 @foreach ($parkingSpots as $parkingSpot)
                     <a class="bp-card-link" href="{{ route('parking_spot.show', ['id' => $parkingSpot->id]) }}">
-                        <img class="h-40 w-full rounded-t-lg object-cover" src="/images/noimage.jpg" alt="駐車場画像">
+                        <img class="h-40 w-full rounded-t-lg object-cover" src="{{ $parkingSpot->image_url }}" alt="駐車場画像">
                         <div class="space-y-3 p-4">
                             <div>
                                 <h3 class="text-lg font-semibold text-slate-900">{{ $parkingSpot->name }}</h3>

--- a/resources/views/parking_spot/confirm.blade.php
+++ b/resources/views/parking_spot/confirm.blade.php
@@ -41,6 +41,11 @@
 
         <div class="grid gap-6 lg:grid-cols-[minmax(0,1fr)_420px]">
             <div class="bp-panel">
+                <div class="overflow-hidden border-b border-slate-100">
+                    <img class="h-72 w-full object-cover"
+                        src="{{ \App\Models\ParkingSpot::imageUrlForPath($validatedData['image_path'] ?? null) }}"
+                        alt="駐輪場画像">
+                </div>
                 <div class="bp-panel-header">
                     <h2 class="bp-section-title">{{ $validatedData['name'] ?? '' }}</h2>
                     <p class="bp-muted mt-1">{{ $validatedData['address'] ?? '' }}</p>
@@ -56,6 +61,10 @@
                     <div class="grid gap-1 py-3 sm:grid-cols-[140px_1fr] sm:gap-4">
                         <dt class="font-semibold text-slate-500">収容台数</dt>
                         <dd class="text-slate-900">{{ $capacity[$validatedData['capacity']] ?? '' }}</dd>
+                    </div>
+                    <div class="grid gap-1 py-3 sm:grid-cols-[140px_1fr] sm:gap-4">
+                        <dt class="font-semibold text-slate-500">画像</dt>
+                        <dd class="text-slate-900">{{ filled($validatedData['image_path'] ?? null) ? '設定あり' : '未設定' }}</dd>
                     </div>
                     <div class="grid gap-1 py-3 sm:grid-cols-[140px_1fr] sm:gap-4">
                         <dt class="font-semibold text-slate-500">営業時間</dt>

--- a/resources/views/parking_spot/create.blade.php
+++ b/resources/views/parking_spot/create.blade.php
@@ -48,6 +48,22 @@
                                     <div class="mt-1 text-sm text-red-600">{{ $message }}</div>
                                 @enderror
                             </div>
+
+                            <div class="md:col-span-2">
+                                <x-input-label for="image">駐輪場画像</x-input-label>
+                                <input class="bp-input" id="image" name="image" type="file" accept="image/*">
+                                <input name="image_path" type="hidden" value="{{ old('image_path') }}">
+                                @if (old('image_path'))
+                                    <img class="mt-3 h-40 w-full rounded-lg object-cover sm:w-72"
+                                        src="{{ \App\Models\ParkingSpot::imageUrlForPath(old('image_path')) }}" alt="アップロード画像プレビュー">
+                                @endif
+                                @error('image')
+                                    <div class="mt-1 text-sm text-red-600">{{ $message }}</div>
+                                @enderror
+                                @error('image_path')
+                                    <div class="mt-1 text-sm text-red-600">{{ $message }}</div>
+                                @enderror
+                            </div>
                         </div>
                     </section>
 

--- a/resources/views/parking_spot/edit.blade.php
+++ b/resources/views/parking_spot/edit.blade.php
@@ -48,6 +48,22 @@
                                     <div class="mt-1 text-sm text-red-600">{{ $message }}</div>
                                 @enderror
                             </div>
+
+                            <div class="md:col-span-2">
+                                <x-input-label for="image">駐輪場画像</x-input-label>
+                                <input class="bp-input" id="image" name="image" type="file" accept="image/*">
+                                <input name="image_path" type="hidden" value="{{ $imagePath }}">
+                                @if ($imagePath)
+                                    <img class="mt-3 h-40 w-full rounded-lg object-cover sm:w-72"
+                                        src="{{ \App\Models\ParkingSpot::imageUrlForPath($imagePath) }}" alt="現在の駐輪場画像">
+                                @endif
+                                @error('image')
+                                    <div class="mt-1 text-sm text-red-600">{{ $message }}</div>
+                                @enderror
+                                @error('image_path')
+                                    <div class="mt-1 text-sm text-red-600">{{ $message }}</div>
+                                @enderror
+                            </div>
                         </div>
                     </section>
 

--- a/resources/views/parking_spot/show.blade.php
+++ b/resources/views/parking_spot/show.blade.php
@@ -40,7 +40,7 @@
         <div class="grid gap-6 lg:grid-cols-[minmax(0,1fr)_380px]">
             <div class="space-y-6">
                 <div class="bp-panel">
-                    <img class="h-72 w-full object-cover" src="/images/noimage.jpg" alt="駐車場の写真">
+                    <img class="h-72 w-full object-cover" src="{{ $parkingSpot->image_url }}" alt="駐車場の写真">
                 </div>
 
                 <div class="bp-panel">

--- a/tests/Feature/ParkingSpotRateDisplayTest.php
+++ b/tests/Feature/ParkingSpotRateDisplayTest.php
@@ -139,6 +139,34 @@ class ParkingSpotRateDisplayTest extends TestCase
         $response->assertSee('/storage/'.$imagePath);
     }
 
+    public function test_parking_spot_confirm_rejects_unsupported_image_extension(): void
+    {
+        [, $user, $postalcode] = $this->createParkingSpot();
+
+        $response = $this->actingAs($user)
+            ->from(route('parking_spot.create'))
+            ->post(route('parking_spot.confirm'), $this->validParkingSpotInput($postalcode, [
+                'image' => UploadedFile::fake()->create('parking-spot.gif', 100, 'image/gif'),
+            ]));
+
+        $response->assertRedirect(route('parking_spot.create'));
+        $response->assertSessionHasErrors(['image']);
+    }
+
+    public function test_parking_spot_confirm_rejects_oversized_image(): void
+    {
+        [, $user, $postalcode] = $this->createParkingSpot();
+
+        $response = $this->actingAs($user)
+            ->from(route('parking_spot.create'))
+            ->post(route('parking_spot.confirm'), $this->validParkingSpotInput($postalcode, [
+                'image' => UploadedFile::fake()->image('parking-spot.jpg')->size(21000),
+            ]));
+
+        $response->assertRedirect(route('parking_spot.create'));
+        $response->assertSessionHasErrors(['image']);
+    }
+
     public function test_parking_spot_can_save_multiple_rates(): void
     {
         [$parkingSpot, $user, $postalcode] = $this->createParkingSpot();
@@ -231,7 +259,7 @@ class ParkingSpotRateDisplayTest extends TestCase
         $parkingSpot = ParkingSpot::where('name', '登録Featureテスト駐車場')->firstOrFail();
         $this->assertNotNull($parkingSpot->image_path);
         $this->assertMatchesRegularExpression(
-            '/^parking-spots\/'.$parkingSpot->id.'_\d{17}\.jpg$/',
+            '/^parking-spots\/'.$parkingSpot->id.'_\d{17}\.webp$/',
             $parkingSpot->image_path
         );
         Storage::disk('public')->assertExists($parkingSpot->image_path);
@@ -520,7 +548,7 @@ class ParkingSpotRateDisplayTest extends TestCase
         $parkingSpot->refresh();
         $this->assertNotSame('parking-spots/original.jpg', $parkingSpot->image_path);
         $this->assertMatchesRegularExpression(
-            '/^parking-spots\/'.$parkingSpot->id.'_\d{17}\.jpg$/',
+            '/^parking-spots\/'.$parkingSpot->id.'_\d{17}\.webp$/',
             $parkingSpot->image_path
         );
         Storage::disk('public')->assertMissing('parking-spots/original.jpg');

--- a/tests/Feature/ParkingSpotRateDisplayTest.php
+++ b/tests/Feature/ParkingSpotRateDisplayTest.php
@@ -10,8 +10,11 @@ use App\Models\Prefecture;
 use App\Models\User;
 use App\Services\ParkingSpotService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Livewire;
 use Tests\TestCase;
 
 class ParkingSpotRateDisplayTest extends TestCase
@@ -104,6 +107,36 @@ class ParkingSpotRateDisplayTest extends TestCase
 
         $response->assertOk();
         $response->assertSee('料金未登録');
+        $response->assertSee('/images/noimage.jpg');
+    }
+
+    public function test_parking_spot_confirm_stores_uploaded_image_path_in_session(): void
+    {
+        [, $user, $postalcode] = $this->createParkingSpot();
+        Storage::fake('public');
+        Http::fake([
+            '*' => Http::response([
+                'Feature' => [
+                    [
+                        'Geometry' => ['Coordinates' => '139.753000,35.685000'],
+                        'Property' => ['Address' => '東京都千代田区千代田1-2'],
+                    ],
+                ],
+            ]),
+        ]);
+
+        $response = $this->actingAs($user)
+            ->from(route('parking_spot.create'))
+            ->post(route('parking_spot.confirm'), $this->validParkingSpotInput($postalcode, [
+                'image' => UploadedFile::fake()->image('parking-spot.jpg'),
+            ]));
+
+        $response->assertOk();
+        $imagePath = session('create_parking_spot_form.image_path');
+        $this->assertNotNull($imagePath);
+        $this->assertStringStartsWith('temp/parking-spots/', $imagePath);
+        Storage::disk('public')->assertExists($imagePath);
+        $response->assertSee('/storage/'.$imagePath);
     }
 
     public function test_parking_spot_can_save_multiple_rates(): void
@@ -160,6 +193,8 @@ class ParkingSpotRateDisplayTest extends TestCase
     public function test_parking_spot_store_creates_rates_from_confirmed_form(): void
     {
         [, $user, $postalcode] = $this->createParkingSpot();
+        Storage::fake('public');
+        $tempImagePath = UploadedFile::fake()->image('confirmed.jpg')->store('temp/parking-spots', 'public');
 
         $input = [
             'name' => '登録Featureテスト駐車場',
@@ -168,6 +203,7 @@ class ParkingSpotRateDisplayTest extends TestCase
             'longitude' => 139.753000,
             'latitude' => 35.685000,
             'capacity' => 1,
+            'image_path' => $tempImagePath,
             'opening_time' => '00:00',
             'closing_time' => '00:00',
             'rates' => [
@@ -192,6 +228,14 @@ class ParkingSpotRateDisplayTest extends TestCase
             'name' => '登録Featureテスト駐車場',
             'user_id' => $user->id,
         ]);
+        $parkingSpot = ParkingSpot::where('name', '登録Featureテスト駐車場')->firstOrFail();
+        $this->assertNotNull($parkingSpot->image_path);
+        $this->assertMatchesRegularExpression(
+            '/^parking-spots\/'.$parkingSpot->id.'_\d{17}\.jpg$/',
+            $parkingSpot->image_path
+        );
+        Storage::disk('public')->assertExists($parkingSpot->image_path);
+        Storage::disk('public')->assertMissing($tempImagePath);
         $this->assertDatabaseHas('parking_spot_rates', [
             'day_type' => '平日',
             'start_time' => '08:00',
@@ -428,6 +472,10 @@ class ParkingSpotRateDisplayTest extends TestCase
     public function test_parking_spot_update_replaces_rates_from_confirmed_form(): void
     {
         [$parkingSpot, $user, $postalcode] = $this->createParkingSpot();
+        Storage::fake('public');
+        Storage::disk('public')->put('parking-spots/original.jpg', 'original');
+        $parkingSpot->forceFill(['image_path' => 'parking-spots/original.jpg'])->save();
+        $tempImagePath = UploadedFile::fake()->image('updated.jpg')->store('temp/parking-spots', 'public');
 
         ParkingSpotRates::create([
             'parking_spot_id' => $parkingSpot->id,
@@ -448,6 +496,7 @@ class ParkingSpotRateDisplayTest extends TestCase
             'longitude' => 139.754000,
             'latitude' => 35.686000,
             'capacity' => 1,
+            'image_path' => $tempImagePath,
             'opening_time' => '00:00',
             'closing_time' => '00:00',
             'rates' => [
@@ -468,6 +517,15 @@ class ParkingSpotRateDisplayTest extends TestCase
             ->post(route('parking_spot.update'));
 
         $response->assertRedirect(route('home'));
+        $parkingSpot->refresh();
+        $this->assertNotSame('parking-spots/original.jpg', $parkingSpot->image_path);
+        $this->assertMatchesRegularExpression(
+            '/^parking-spots\/'.$parkingSpot->id.'_\d{17}\.jpg$/',
+            $parkingSpot->image_path
+        );
+        Storage::disk('public')->assertMissing('parking-spots/original.jpg');
+        Storage::disk('public')->assertMissing($tempImagePath);
+        Storage::disk('public')->assertExists($parkingSpot->image_path);
         $this->assertDatabaseMissing('parking_spot_rates', [
             'parking_spot_id' => $parkingSpot->id,
             'day_type' => '平日',
@@ -597,6 +655,40 @@ class ParkingSpotRateDisplayTest extends TestCase
 
         $response->assertRedirect(route('parking_spot.create'));
         $response->assertSessionHasErrors(['rates.0.unit_minutes']);
+    }
+
+    public function test_home_displays_uploaded_image_and_fallback_image(): void
+    {
+        [$parkingSpot, $user] = $this->createParkingSpot();
+        $parkingSpot->forceFill(['image_path' => 'parking-spots/home.jpg'])->save();
+
+        ParkingSpot::forceCreate([
+            'user_id' => $user->id,
+            'name' => '画像なし駐車場',
+            'postalcode' => $parkingSpot->postalcode,
+            'address' => '東京都千代田区千代田1-9',
+            'longitude' => 139.759000,
+            'latitude' => 35.689000,
+            'capacity' => 2,
+            'opening_time' => '00:00:00',
+            'closing_time' => '00:00:00',
+        ]);
+
+        $response = $this->get(route('home'));
+
+        $response->assertOk();
+        $response->assertSee('/storage/parking-spots/home.jpg');
+        $response->assertSee('/images/noimage.jpg');
+    }
+
+    public function test_livewire_parking_spots_list_uses_image_url_accessor(): void
+    {
+        [$parkingSpot] = $this->createParkingSpot();
+        $parkingSpot->forceFill(['image_path' => 'parking-spots/list.jpg'])->save();
+
+        Livewire::test(\App\Livewire\ParkingSpots::class)
+            ->set('spots', collect([$parkingSpot->fresh()->load('rates')]))
+            ->assertSee('/storage/parking-spots/list.jpg');
     }
 
     private function createParkingSpot(): array


### PR DESCRIPTION
## 概要
- 駐輪場画像のアップロードと表示に対応
- 画像を WebP に変換して保存し、容量制限を調整
- 画像削除ボタンを追加して noimage に戻せるように対応

## 確認
- 未実施: この環境では Sail が停止中で、ホスト PHP も依存条件と合わないためテスト未実行

Closes #46