### PR TITLE
feat: #54 収容台数表示の変換処理をモデルに集約

### DIFF
--- a/app/Http/Controllers/ParkingSpotController.php
+++ b/app/Http/Controllers/ParkingSpotController.php
@@ -20,10 +20,8 @@ class ParkingSpotController extends Controller
         $parkingSpot = ParkingSpot::with('rates')->findOrFail($id);
 
         $postalcode = Postalcode::getPostalcode($parkingSpot->postalcode)->postalcode;
-        $capacity = config('categories.parking_spot_capacity');
 
         $parkingSpot['postalcode'] = $postalcode;
-        $parkingSpot['capacity'] = $capacity[$parkingSpot['capacity']];
         $parkingSpot['opening_time'] = date('H:i', strtotime($parkingSpot['opening_time']));
         $parkingSpot['closing_time'] = $parkingSpot['closing_time'] === '00:00:00' ? '24:00' : date('H:i', strtotime($parkingSpot['closing_time']));
 

--- a/app/Models/ParkingSpot.php
+++ b/app/Models/ParkingSpot.php
@@ -11,6 +11,13 @@ class ParkingSpot extends Model
 {
     use HasFactory;
 
+    public function getCapacityLabelAttribute(): string
+    {
+        $labels = config('categories.parking_spot_capacity');
+
+        return $labels[$this->capacity] ?? (string) $this->capacity;
+    }
+
     public function getImageUrlAttribute(): string
     {
         return self::imageUrlForPath($this->image_path);

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -36,7 +36,7 @@
                             </div>
                             <div class="flex items-center justify-between border-t border-slate-100 pt-3">
                                 <span class="text-sm font-semibold text-emerald-700">詳細を見る</span>
-                                <span class="text-xs text-slate-500">{{ $parkingSpot->capacity }}台</span>
+                                <span class="text-xs text-slate-500">{{ $parkingSpot->capacity_label }}</span>
                             </div>
                         </div>
                     </a>

--- a/resources/views/parking_spot/show.blade.php
+++ b/resources/views/parking_spot/show.blade.php
@@ -92,7 +92,7 @@
                     <dl class="divide-y divide-slate-100 p-5 text-sm">
                         <div class="grid grid-cols-[96px_1fr] gap-3 py-3 first:pt-0">
                             <dt class="font-semibold text-slate-500">収容台数</dt>
-                            <dd class="text-slate-900">{{ $parkingSpot->capacity }}</dd>
+                            <dd class="text-slate-900">{{ $parkingSpot->capacity_label }}</dd>
                         </div>
                         <div class="grid grid-cols-[96px_1fr] gap-3 pb-2 pt-3">
                             <dt class="font-semibold text-slate-500">営業時間</dt>


### PR DESCRIPTION
## 概要
- 収容台数の表示ラベル変換を ParkingSpot モデルのアクセサに集約
- Home / 詳細画面の表示を capacity_label 参照に統一
- コントローラ内の重複変換処理を削除

## テスト
- 未実施

Closes #54